### PR TITLE
CI: Ensure workflows run only on storybookjs, and add fork-only basic checks

### DIFF
--- a/.github/workflows/cron-weekly.yml
+++ b/.github/workflows/cron-weekly.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   check-links:
+    if: github.repository_owner == 'storybookjs'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/fork-checks.yml
+++ b/.github/workflows/fork-checks.yml
@@ -1,4 +1,4 @@
-name: Unit tests
+name: Fork Checks
 
 on:
   push:
@@ -11,31 +11,9 @@ env:
   NODE_OPTIONS: '--max_old_space_size=4096'
 
 jobs:
-  build:
-    name: Core Unit Tests, windows-latest
-    runs-on: windows-11-arm
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 2
-
-      - name: Setup Node.js and Install Dependencies
-        uses: ./.github/actions/setup-node-and-install
-        with:
-          install-code-deps: true
-
-      - name: compile
-        run: yarn task --task compile --start-from=compile
-
-      - name: Install Playwright Dependencies
-        run: cd code && yarn exec playwright install chromium --with-deps
-
-      - name: test
-        run: yarn test
-
   # This job is only for forks, so they can get basic checks in without a CircleCI API key
-  linux:
-    name: Core Unit Tests, ubuntu-latest
+  check:
+    name: Core Type Checking
     if: github.repository_owner != 'storybookjs'
     runs-on: ubuntu-latest
     steps:
@@ -48,11 +26,23 @@ jobs:
         with:
           install-code-deps: true
 
-      - name: compile
-        run: yarn task --task compile --start-from=compile
+      - name: check
+        run: yarn task --task check
 
-      - name: Install Playwright Dependencies
-        run: cd code && yarn exec playwright install chromium --with-deps
+  # This job is only for forks, so they can get basic checks in without a CircleCI API key
+  prettier:
+    name: Core Formatting
+    if: github.repository_owner != 'storybookjs'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
 
-      - name: test
-        run: yarn test
+      - name: Setup Node.js and Install Dependencies
+        uses: ./.github/actions/setup-node-and-install
+        with:
+          install-code-deps: true
+
+      - name: prettier
+        run: yarn lint:prettier --check code

--- a/.github/workflows/fork-checks.yml
+++ b/.github/workflows/fork-checks.yml
@@ -1,4 +1,4 @@
-name: Fork Checks
+name: Fork checks
 
 on:
   push:
@@ -45,4 +45,4 @@ jobs:
           install-code-deps: true
 
       - name: prettier
-        run: yarn lint:prettier --check code
+        run: cd code && yarn lint:prettier --check .

--- a/.github/workflows/generate-sandboxes.yml
+++ b/.github/workflows/generate-sandboxes.yml
@@ -24,6 +24,7 @@ defaults:
 jobs:
   generate-next:
     name: Generate to next
+    if: github.repository_owner == 'storybookjs'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -76,6 +77,7 @@ jobs:
 
   generate-main:
     name: Generate to main
+    if: github.repository_owner == 'storybookjs'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/handle-release-branches.yml
+++ b/.github/workflows/handle-release-branches.yml
@@ -5,6 +5,7 @@ on:
 
 jobs:
   branch-checks:
+    if: github.repository_owner == 'storybookjs'
     runs-on: ubuntu-latest
     steps:
       - id: get-branch

--- a/.github/workflows/handle-release-branches.yml
+++ b/.github/workflows/handle-release-branches.yml
@@ -69,7 +69,7 @@ jobs:
       branch: ${{ needs.get-next-release-branch.outputs.branch }}
 
   next-release-branch-check:
-    if: ${{ always() }}
+    if: ${{ always() && github.repository_owner == 'storybookjs' }}
     needs: [branch-checks, get-next-release-branch]
     runs-on: ubuntu-latest
     steps:
@@ -88,7 +88,7 @@ jobs:
       check: ${{ env.is-next-release-branch }}
 
   request-create-frontpage-branch:
-    if: ${{ always() }}
+    if: ${{ always() && github.repository_owner == 'storybookjs' }}
     needs:
       [branch-checks, next-release-branch-check, create-next-release-branch]
     runs-on: ubuntu-latest

--- a/.github/workflows/prepare-non-patch-release.yml
+++ b/.github/workflows/prepare-non-patch-release.yml
@@ -36,6 +36,7 @@ concurrency:
 jobs:
   prepare-non-patch-pull-request:
     name: Prepare non-patch pull request
+    if: github.repository_owner == 'storybookjs'
     runs-on: ubuntu-latest
     environment: Release
     defaults:

--- a/.github/workflows/prepare-patch-release.yml
+++ b/.github/workflows/prepare-patch-release.yml
@@ -18,6 +18,7 @@ concurrency:
 jobs:
   prepare-patch-pull-request:
     name: Prepare patch pull request
+    if: github.repository_owner == 'storybookjs'
     runs-on: ubuntu-latest
     environment: Release
     defaults:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,6 +39,7 @@ jobs:
     name: Publish normal version
     runs-on: ubuntu-latest
     if: |
+      github.repository_owner == 'storybookjs' &&
       github.event_name == 'push' &&
       (github.ref_name == 'latest-release' || github.ref_name == 'next-release') &&
       contains(github.event.head_commit.message, '[skip ci]') != true
@@ -221,6 +222,7 @@ jobs:
     name: Publish canary version
     runs-on: ubuntu-latest
     if: |
+      github.repository_owner == 'storybookjs' &&
       (
         github.event_name == 'workflow_dispatch' ||
         (github.event_name == 'pull_request' && endsWith(github.head_ref, 'with-canary-release'))

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -6,6 +6,7 @@ on:
 jobs:
   stale:
     runs-on: ubuntu-latest
+    if: github.repository_owner == 'storybookjs'
     steps:
       - uses: actions/stale@v9
         with:

--- a/.github/workflows/tests-unit.yml
+++ b/.github/workflows/tests-unit.yml
@@ -8,7 +8,7 @@ on:
     types: [opened, synchronize, reopened]
 
 env:
-  NODE_OPTIONS: "--max_old_space_size=4096"
+  NODE_OPTIONS: '--max_old_space_size=4096'
 
 jobs:
   build:
@@ -32,3 +32,63 @@ jobs:
 
       - name: test
         run: yarn test
+
+  # This job is only for forks, so they can get basic checks in without a CircleCI API key
+  linux:
+    name: Core Unit Tests, ubuntu-latest
+    if: github.repository_owner != 'storybookjs'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Setup Node.js and Install Dependencies
+        uses: ./.github/actions/setup-node-and-install
+        with:
+          install-code-deps: true
+
+      - name: compile
+        run: yarn task --task compile --start-from=compile
+
+      - name: Install Playwright Dependencies
+        run: cd code && yarn exec playwright install chromium --with-deps
+
+      - name: test
+        run: yarn test
+
+  # This job is only for forks, so they can get basic checks in without a CircleCI API key
+  check:
+    name: Core Type Checking
+    if: github.repository_owner != 'storybookjs'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Setup Node.js and Install Dependencies
+        uses: ./.github/actions/setup-node-and-install
+        with:
+          install-code-deps: true
+
+      - name: check
+        run: yarn task --task check
+
+  # This job is only for forks, so they can get basic checks in without a CircleCI API key
+  prettier:
+    name: Core Formatting
+    if: github.repository_owner != 'storybookjs'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Setup Node.js and Install Dependencies
+        uses: ./.github/actions/setup-node-and-install
+        with:
+          install-code-deps: true
+
+      - name: prettier
+        run: yarn lint:prettier --check code

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -15,6 +15,7 @@ permissions:
 jobs:
   triage:
     name: Nissuer
+    if: github.repository_owner == 'storybookjs'
     runs-on: ubuntu-latest
     steps:
       - uses: balazsorban44/nissuer@1.10.0

--- a/.github/workflows/trigger-circle-ci-workflow.yml
+++ b/.github/workflows/trigger-circle-ci-workflow.yml
@@ -16,6 +16,7 @@ concurrency:
 
 jobs:
   get-branch:
+    if: github.repository_owner == 'storybookjs'
     runs-on: ubuntu-latest
     steps:
       - id: get-branch
@@ -37,6 +38,7 @@ jobs:
       branch: ${{ env.branch }}
 
   get-parameters:
+    if: github.repository_owner == 'storybookjs'
     runs-on: ubuntu-latest
     steps:
       - if: github.event_name == 'pull_request_target' && (contains(github.event.pull_request.labels.*.name, 'ci:normal'))
@@ -55,7 +57,7 @@ jobs:
   trigger-circle-ci-workflow:
     runs-on: ubuntu-latest
     needs: [get-branch, get-parameters]
-    if: needs.get-parameters.outputs.workflow != ''
+    if: needs.get-parameters.outputs.workflow != '' && github.repository_owner == 'storybookjs'
     steps:
       - name: Trigger Normal tests
         uses: fjogeleit/http-request-action@v1

--- a/code/.prettierignore
+++ b/code/.prettierignore
@@ -8,3 +8,6 @@ bench
 core/report
 
 /.nx/workspace-data
+
+# This file contains imports with an order that must be preserved.
+core/src/core-server/presets/common-manager.ts

--- a/code/frameworks/angular/build-schema.json
+++ b/code/frameworks/angular/build-schema.json
@@ -67,27 +67,18 @@
     "compodocArgs": {
       "type": "array",
       "description": "Compodoc options : https://compodoc.app/guides/options.html. Options `-p` with tsconfig path and `-d` with workspace root is always given.",
-      "default": [
-        "-e",
-        "json"
-      ],
+      "default": ["-e", "json"],
       "items": {
         "type": "string"
       }
     },
     "webpackStatsJson": {
-      "type": [
-        "boolean",
-        "string"
-      ],
+      "type": ["boolean", "string"],
       "description": "Write Webpack Stats JSON to disk",
       "default": false
     },
     "statsJson": {
-      "type": [
-        "boolean",
-        "string"
-      ],
+      "type": ["boolean", "string"],
       "description": "Write stats JSON to disk",
       "default": false
     },
@@ -125,10 +116,7 @@
       }
     },
     "sourceMap": {
-      "type": [
-        "boolean",
-        "object"
-      ],
+      "type": ["boolean", "object"],
       "description": "Configure sourcemaps. See: https://angular.io/guide/workspace-config#source-map-configuration",
       "default": false
     },
@@ -170,11 +158,7 @@
             }
           },
           "additionalProperties": false,
-          "required": [
-            "glob",
-            "input",
-            "output"
-          ]
+          "required": ["glob", "input", "output"]
         },
         {
           "type": "string"
@@ -202,9 +186,7 @@
             }
           },
           "additionalProperties": false,
-          "required": [
-            "input"
-          ]
+          "required": ["input"]
         },
         {
           "type": "string",

--- a/code/frameworks/angular/start-schema.json
+++ b/code/frameworks/angular/start-schema.json
@@ -93,10 +93,7 @@
     "compodocArgs": {
       "type": "array",
       "description": "Compodoc options : https://compodoc.app/guides/options.html. Options `-p` with tsconfig path and `-d` with workspace root is always given.",
-      "default": [
-        "-e",
-        "json"
-      ],
+      "default": ["-e", "json"],
       "items": {
         "type": "string"
       }
@@ -135,18 +132,12 @@
       "description": "URL path to be appended when visiting Storybook for the first time"
     },
     "webpackStatsJson": {
-      "type": [
-        "boolean",
-        "string"
-      ],
+      "type": ["boolean", "string"],
       "description": "Write Webpack Stats JSON to disk",
       "default": false
     },
     "statsJson": {
-      "type": [
-        "boolean",
-        "string"
-      ],
+      "type": ["boolean", "string"],
       "description": "Write stats JSON to disk",
       "default": false
     },
@@ -160,10 +151,7 @@
       "pattern": "(silly|verbose|info|warn|silent)"
     },
     "sourceMap": {
-      "type": [
-        "boolean",
-        "object"
-      ],
+      "type": ["boolean", "object"],
       "description": "Configure sourcemaps. See: https://angular.io/guide/workspace-config#source-map-configuration",
       "default": false
     },
@@ -205,11 +193,7 @@
             }
           },
           "additionalProperties": false,
-          "required": [
-            "glob",
-            "input",
-            "output"
-          ]
+          "required": ["glob", "input", "output"]
         },
         {
           "type": "string"
@@ -237,9 +221,7 @@
             }
           },
           "additionalProperties": false,
-          "required": [
-            "input"
-          ]
+          "required": ["input"]
         },
         {
           "type": "string",

--- a/code/frameworks/server-webpack5/template/cli/page.stories.yaml
+++ b/code/frameworks/server-webpack5/template/cli/page.stories.yaml
@@ -1,10 +1,10 @@
-title: "Example/Page"
+title: 'Example/Page'
 parameters:
   server:
-    url: "https://storybook-server-demo.netlify.app/api"
-    id: "page"
+    url: 'https://storybook-server-demo.netlify.app/api'
+    id: 'page'
 stories:
-  - name: "LoggedIn"
+  - name: 'LoggedIn'
     args:
       user: {}
-  - name: "LoggedOut"
+  - name: 'LoggedOut'

--- a/code/frameworks/sveltekit/tsconfig.json
+++ b/code/frameworks/sveltekit/tsconfig.json
@@ -3,7 +3,7 @@
     "baseUrl": ".",
     "paths": {
       "storybook/internal/*": ["../../lib/cli/core/*"]
-    },
+    }
   },
   "extends": "../../tsconfig.json",
   "include": ["src/**/*"]

--- a/code/lib/eslint-plugin/docs/rules/no-stories-of.md
+++ b/code/lib/eslint-plugin/docs/rules/no-stories-of.md
@@ -14,7 +14,6 @@ Examples of **incorrect** code for this rule:
 
 ```js
 import { storiesOf } from '@storybook/react';
-
 import Button from '../components/Button';
 
 storiesOf('Button', module).add('primary', () => <Button primary />);


### PR DESCRIPTION
Testing CI behaviour.

## Prior to CI changes
* CI on the branch runs fine without edits
* CI in PRs from fork to fork run fine but lack test/build/check/lint workflows
* If applying `ci:` labels, PRs from fork to fork fail on 403 as there is no CircleCI token

## After CI changes
* check/prettier/test jobs run locally
* All jobs requiring our credentials / org secrets are disabled
